### PR TITLE
fix indent line bug

### DIFF
--- a/d2-mode.el
+++ b/d2-mode.el
@@ -218,7 +218,6 @@ Optional argument BROWSE whether to open the browser."
 (define-derived-mode d2-mode prog-mode "d2"
   :syntax-table d2-syntax-table
   (setq-local font-lock-defaults '(d2-font-lock-keywords))
-  (setq-local indent-line-function 'd2-indent-line)
   (setq-local comment-start "%%")
   (setq-local comment-end "")
   (setq-local comment-start-skip "%%+ *"))


### PR DESCRIPTION
fixes the indent line bug from https://github.com/andorsk/d2-mode/issues/22. d2 mode on the autoload was calling a missing function.