### PR TITLE
d2 has no shorthand flag 'o'. Update to support org-src.

### DIFF
--- a/d2-mode.el
+++ b/d2-mode.el
@@ -114,7 +114,7 @@
                        (error "D2 requires a \":file\" header argument")))
          (temp-file (org-babel-temp-file "d2-"))
          (cmd (concat (shell-quote-argument d2-location)
-                      " " temp-file                      
+                      " " temp-file
                       " " (org-babel-process-file-name out-file)
                       " " d2-flags)))
     (with-temp-file temp-file (insert body))

--- a/d2-mode.el
+++ b/d2-mode.el
@@ -114,8 +114,8 @@
                        (error "D2 requires a \":file\" header argument")))
          (temp-file (org-babel-temp-file "d2-"))
          (cmd (concat (shell-quote-argument d2-location)
-                      " -o " (org-babel-process-file-name out-file)
-                      " -i " temp-file
+                      " " temp-file                      
+                      " " (org-babel-process-file-name out-file)
                       " " d2-flags)))
     (with-temp-file temp-file (insert body))
     (org-babel-eval cmd "")


### PR DESCRIPTION
Based on d2 help doc, d2 doesn't have shorthand flag 'o'. Change `org-babel-default-header-args:d2` function to make org-src block work.
```
$ d2 --help
Usage:
  d2 [--watch=false] [--theme=0] file.d2 [file.svg | file.png]
  d2 layout [name]
  d2 fmt file.d2

d2 compiles and renders file.d2 to file.svg | file.png
It defaults to file.svg if an output path is not provided.

Use - to have d2 read from stdin or write to stdout.

See man d2 for more detailed docs.

Flags:
  -w, --watch           $D2_WATCH   watch for changes to input and live reload. Use $HOST and $PORT to specify the listening address.
                                    (default localhost:0, which is will open on a randomly available local port). (default false)
  -h, --host string     $HOST       host listening address when used with watch (default "localhost")
  -p, --port string     $PORT       port listening address when used with watch (default "0")
  -b, --bundle          $D2_BUNDLE  when outputting SVG, bundle all assets and layers into the output file. (default true)
  -d, --debug           $DEBUG      print debug logs. (default false)
  -l, --layout string   $D2_LAYOUT  the layout engine used. (default "dagre")
  -t, --theme int       $D2_THEME   the diagram theme ID. For a list of available options, see https://oss.terrastruct.com/d2 (default 0)
  -v, --version                     get the version (default false)


Subcommands:
  d2 layout - Lists available layout engine options with short help
  d2 layout [name] - Display long help for a particular layout engine
  d2 fmt file.d2 - Format file.d2

See more docs and the source code at https://oss.terrastruct.com/d2
```