### PR TITLE
Remove unnecessary use of shell-quote-argument

### DIFF
--- a/d2-mode.el
+++ b/d2-mode.el
@@ -329,7 +329,7 @@ Argument FILE-NAME the input file."
   (interactive "fFilename: ")
   (let* ((input file-name)
          (output (concat (file-name-sans-extension input) d2-output-format)))
-    (apply #'call-process (shell-quote-argument d2-location) nil "*d2*" nil (append (list input output) d2-flags))
+    (apply #'call-process d2-location nil "*d2*" nil (append (list input output) d2-flags))
     (if (equal browse t)
         (progn
           (d2-browse-file output))


### PR DESCRIPTION
Hello,

You don't have to `shell-quote-argument` the executable name when you pass it to `call-process`. Actually, it doesn't work on Windows where actual executable files are suffixed with `.exe`. It's better to pass the name without quoting, so `call-process` can find it from `exec-path`.